### PR TITLE
change docker file to run voila instead of jupyter notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 .*_cache
 Playground.*
 dev_websites/*
+*.prod.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ ENV LC_ALL=de_DE.UTF-8
 ENV LANG=de_DE.UTF-8
 ENV LANGUAGE=de_DE:de
 
-# Install Jupyter and dependencies
-RUN pip install --no-cache-dir jupyter notebook
+# Install Jupyter and Voila
+RUN pip install --no-cache-dir jupyter notebook voila
 
 # Set up the working directory
 WORKDIR /app
@@ -23,8 +23,9 @@ COPY . .
 # Set PYTHONPATH
 ENV PYTHONPATH=/app/src
 
-# Expose Jupyter Notebook port
-EXPOSE 8888
+# Expose Voila port
+EXPOSE 8866
 
-# Start Jupyter Notebook
-CMD ["jupyter", "notebook", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root", "--NotebookApp.log_level=DEBUG"]
+# Start Voila serving main.ipynb
+CMD ["voila", "main.ipynb", "--no-browser", "--Voila.ip=0.0.0.0", "--Voila.port=8866"]
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # DIDDI
 ## How to use with Docker
-0. Set variables in settings properly for docker usage
+Set variables in settings properly for docker usage
+### Option 1
+You can now run docker compose up and the image will be built and run on port 8866 (voila standard port).
+Openlocalhost:8866 in your browse
+### Option 2
 1. Dockerfile must be called Dockerfile without file-extension.
 2. run:
    ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  diddi:
+    build:
+      context: .
+    ports:
+      - "8866:8866"


### PR DESCRIPTION
added docker-compose.yml
You can now run `docker compose up` and the image will be built and run on port 8866 (voila standard port).
Open`localhost:8866` in your browser